### PR TITLE
docs: add frontmatter description for llms.txt hierarchy

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: DNS
+description: DNS management, zones, and load balancing for F5 Distributed Cloud.
 hero:
   tagline: DNS management, zones, and load balancing.
   image:


### PR DESCRIPTION
## Summary

- Adds a `description:` field to the `docs/index.mdx` frontmatter so the starlight-llms-txt plugin includes page-level metadata in the llms.txt output

Refs f5xc-salesdemos/xcsh#223

Step 5c of the cascading llms.txt knowledge hierarchy -- adds a `description:` field to the index page frontmatter so the starlight-llms-txt plugin can include it in the llms.txt output.

Closes #233

## Test plan

- [ ] CI checks pass
- [ ] Verify the frontmatter is valid YAML with the new `description:` field
- [ ] Confirm the starlight-llms-txt plugin picks up the description in the llms.txt output