### PR TITLE
feat: add F5 XC DNS zone manifests for demo domains

### DIFF
--- a/manifests/f5-sales-demo-ca.json
+++ b/manifests/f5-sales-demo-ca.json
@@ -23,9 +23,7 @@
               "ttl": 300,
               "a_record": {
                 "name": "www",
-                "values": [
-                  "203.0.113.50"
-                ]
+                "values": ["203.0.113.50"]
               },
               "description": "Web server"
             },
@@ -33,9 +31,7 @@
               "ttl": 300,
               "a_record": {
                 "name": "app",
-                "values": [
-                  "203.0.113.60"
-                ]
+                "values": ["203.0.113.60"]
               },
               "description": "Application server"
             },
@@ -51,9 +47,7 @@
               "ttl": 3600,
               "mx_record": {
                 "name": "",
-                "values": [
-                  "10 mail.f5-sales-demo.ca"
-                ]
+                "values": ["10 mail.f5-sales-demo.ca"]
               },
               "description": "Mail exchange record"
             },
@@ -61,9 +55,7 @@
               "ttl": 3600,
               "txt_record": {
                 "name": "",
-                "values": [
-                  "v=spf1 include:_spf.f5.com ~all"
-                ]
+                "values": ["v=spf1 include:_spf.f5.com ~all"]
               },
               "description": "SPF record for email authentication"
             },
@@ -71,9 +63,7 @@
               "ttl": 300,
               "aaaa_record": {
                 "name": "www",
-                "values": [
-                  "2001:db8::50"
-                ]
+                "values": ["2001:db8::50"]
               },
               "description": "IPv6 web server"
             }

--- a/manifests/f5-sales-demo-ca.json
+++ b/manifests/f5-sales-demo-ca.json
@@ -1,0 +1,85 @@
+{
+  "kind": "dns_zone",
+  "metadata": {
+    "name": "f5-sales-demo.ca",
+    "namespace": "system",
+    "description": "Primary DNS zone for f5-sales-demo.ca demo domain"
+  },
+  "spec": {
+    "primary": {
+      "default_soa_parameters": {},
+      "dnssec_mode": {
+        "disable": {}
+      },
+      "allow_http_lb_managed_records": true,
+      "rr_set_group": [
+        {
+          "metadata": {
+            "name": "demo-records",
+            "description": "Demo DNS records for f5-sales-demo.ca"
+          },
+          "rr_set": [
+            {
+              "ttl": 300,
+              "a_record": {
+                "name": "www",
+                "values": [
+                  "203.0.113.50"
+                ]
+              },
+              "description": "Web server"
+            },
+            {
+              "ttl": 300,
+              "a_record": {
+                "name": "app",
+                "values": [
+                  "203.0.113.60"
+                ]
+              },
+              "description": "Application server"
+            },
+            {
+              "ttl": 3600,
+              "cname_record": {
+                "name": "api",
+                "value": "api.f5-sales-demo.com"
+              },
+              "description": "API alias to .com domain"
+            },
+            {
+              "ttl": 3600,
+              "mx_record": {
+                "name": "",
+                "values": [
+                  "10 mail.f5-sales-demo.ca"
+                ]
+              },
+              "description": "Mail exchange record"
+            },
+            {
+              "ttl": 3600,
+              "txt_record": {
+                "name": "",
+                "values": [
+                  "v=spf1 include:_spf.f5.com ~all"
+                ]
+              },
+              "description": "SPF record for email authentication"
+            },
+            {
+              "ttl": 300,
+              "aaaa_record": {
+                "name": "www",
+                "values": [
+                  "2001:db8::50"
+                ]
+              },
+              "description": "IPv6 web server"
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/manifests/f5-sales-demo-com.json
+++ b/manifests/f5-sales-demo-com.json
@@ -1,0 +1,106 @@
+{
+  "kind": "dns_zone",
+  "metadata": {
+    "name": "f5-sales-demo.com",
+    "namespace": "system",
+    "description": "Primary DNS zone for f5-sales-demo.com demo domain"
+  },
+  "spec": {
+    "primary": {
+      "default_soa_parameters": {},
+      "dnssec_mode": {
+        "disable": {}
+      },
+      "allow_http_lb_managed_records": true,
+      "rr_set_group": [
+        {
+          "metadata": {
+            "name": "demo-records",
+            "description": "Demo DNS records for f5-sales-demo.com"
+          },
+          "rr_set": [
+            {
+              "ttl": 300,
+              "a_record": {
+                "name": "www",
+                "values": [
+                  "203.0.113.10"
+                ]
+              },
+              "description": "Web server"
+            },
+            {
+              "ttl": 300,
+              "a_record": {
+                "name": "app",
+                "values": [
+                  "203.0.113.20"
+                ]
+              },
+              "description": "Application server"
+            },
+            {
+              "ttl": 300,
+              "a_record": {
+                "name": "api",
+                "values": [
+                  "203.0.113.30"
+                ]
+              },
+              "description": "API endpoint"
+            },
+            {
+              "ttl": 3600,
+              "cname_record": {
+                "name": "cdn",
+                "value": "cdn.f5-sales-demo.com.cdn.cloudflare.net"
+              },
+              "description": "CDN alias"
+            },
+            {
+              "ttl": 3600,
+              "mx_record": {
+                "name": "",
+                "values": [
+                  "10 mail.f5-sales-demo.com",
+                  "20 mail2.f5-sales-demo.com"
+                ]
+              },
+              "description": "Mail exchange records"
+            },
+            {
+              "ttl": 3600,
+              "txt_record": {
+                "name": "",
+                "values": [
+                  "v=spf1 include:_spf.f5.com ~all"
+                ]
+              },
+              "description": "SPF record for email authentication"
+            },
+            {
+              "ttl": 300,
+              "txt_record": {
+                "name": "_dmarc",
+                "values": [
+                  "v=DMARC1; p=reject; rua=mailto:dmarc@f5-sales-demo.com"
+                ]
+              },
+              "description": "DMARC policy"
+            },
+            {
+              "ttl": 300,
+              "aaaa_record": {
+                "name": "www",
+                "values": [
+                  "2001:db8::10"
+                ]
+              },
+              "description": "IPv6 web server"
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/manifests/f5-sales-demo-com.json
+++ b/manifests/f5-sales-demo-com.json
@@ -23,9 +23,7 @@
               "ttl": 300,
               "a_record": {
                 "name": "www",
-                "values": [
-                  "203.0.113.10"
-                ]
+                "values": ["203.0.113.10"]
               },
               "description": "Web server"
             },
@@ -33,9 +31,7 @@
               "ttl": 300,
               "a_record": {
                 "name": "app",
-                "values": [
-                  "203.0.113.20"
-                ]
+                "values": ["203.0.113.20"]
               },
               "description": "Application server"
             },
@@ -43,9 +39,7 @@
               "ttl": 300,
               "a_record": {
                 "name": "api",
-                "values": [
-                  "203.0.113.30"
-                ]
+                "values": ["203.0.113.30"]
               },
               "description": "API endpoint"
             },
@@ -61,10 +55,7 @@
               "ttl": 3600,
               "mx_record": {
                 "name": "",
-                "values": [
-                  "10 mail.f5-sales-demo.com",
-                  "20 mail2.f5-sales-demo.com"
-                ]
+                "values": ["10 mail.f5-sales-demo.com", "20 mail2.f5-sales-demo.com"]
               },
               "description": "Mail exchange records"
             },
@@ -72,9 +63,7 @@
               "ttl": 3600,
               "txt_record": {
                 "name": "",
-                "values": [
-                  "v=spf1 include:_spf.f5.com ~all"
-                ]
+                "values": ["v=spf1 include:_spf.f5.com ~all"]
               },
               "description": "SPF record for email authentication"
             },
@@ -82,9 +71,7 @@
               "ttl": 300,
               "txt_record": {
                 "name": "_dmarc",
-                "values": [
-                  "v=DMARC1; p=reject; rua=mailto:dmarc@f5-sales-demo.com"
-                ]
+                "values": ["v=DMARC1; p=reject; rua=mailto:dmarc@f5-sales-demo.com"]
               },
               "description": "DMARC policy"
             },
@@ -92,9 +79,7 @@
               "ttl": 300,
               "aaaa_record": {
                 "name": "www",
-                "values": [
-                  "2001:db8::10"
-                ]
+                "values": ["2001:db8::10"]
               },
               "description": "IPv6 web server"
             }


### PR DESCRIPTION
## Summary
- Adds `manifests/f5-sales-demo-ca.json` and `manifests/f5-sales-demo-com.json` with F5 XC DNS zone definitions
- Includes A, AAAA, CNAME, MX, TXT, and DMARC records using documentation-range placeholder IPs

Closes #493

## Test plan
- [ ] Verify JSON is valid and parseable
- [ ] Confirm records match expected demo domain structure

🤖 Generated with [Claude Code](https://claude.com/claude-code)