### PR TITLE
feat(terraform): promote DNS plan to production tenant + Azure remote state

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -3,8 +3,9 @@ name: Terraform
 
 # Plan on PRs, apply on merge to main. State lives in Azure Blob Storage
 # (azurerm backend, access-key auth); the xcsh provider authenticates to the
-# production F5 XC tenant. All credentials come from repo secrets, injected only
-# into the steps that need them.
+# production F5 XC tenant. Nothing environment-specific is hardcoded: backend
+# coords and inputs come from GitHub repository variables (vars.*), credentials
+# from secrets (secrets.*), injected only into the steps that need them.
 on:
   pull_request:
     branches: [main]
@@ -41,7 +42,16 @@ jobs:
       - name: Init
         env:
           ARM_ACCESS_KEY: ${{ secrets.ARM_ACCESS_KEY }}
-        run: terraform init -input=false
+          RESOURCE_GROUP: ${{ vars.TFSTATE_RESOURCE_GROUP }}
+          STORAGE_ACCOUNT: ${{ vars.TFSTATE_STORAGE_ACCOUNT }}
+          CONTAINER: ${{ vars.TFSTATE_CONTAINER }}
+          STATE_KEY: ${{ vars.TFSTATE_KEY }}
+        run: |
+          terraform init -input=false \
+            -backend-config="resource_group_name=${RESOURCE_GROUP}" \
+            -backend-config="storage_account_name=${STORAGE_ACCOUNT}" \
+            -backend-config="container_name=${CONTAINER}" \
+            -backend-config="key=${STATE_KEY}"
 
       - name: Format check
         run: terraform fmt -check -recursive
@@ -55,6 +65,8 @@ jobs:
           ARM_ACCESS_KEY: ${{ secrets.ARM_ACCESS_KEY }}
           XCSH_API_URL: ${{ secrets.XCSH_API_URL }}
           XCSH_API_TOKEN: ${{ secrets.XCSH_API_TOKEN }}
+          TF_VAR_domain: ${{ vars.DNS_DOMAIN }}
+          TF_VAR_namespace: ${{ vars.DNS_NAMESPACE }}
         run: terraform plan -input=false -no-color
 
       - name: Apply
@@ -63,4 +75,6 @@ jobs:
           ARM_ACCESS_KEY: ${{ secrets.ARM_ACCESS_KEY }}
           XCSH_API_URL: ${{ secrets.XCSH_API_URL }}
           XCSH_API_TOKEN: ${{ secrets.XCSH_API_TOKEN }}
+          TF_VAR_domain: ${{ vars.DNS_DOMAIN }}
+          TF_VAR_namespace: ${{ vars.DNS_NAMESPACE }}
         run: terraform apply -input=false -auto-approve -no-color

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -1,0 +1,60 @@
+---
+name: Terraform
+
+# Plan on PRs, apply on merge to main. State lives in Azure Blob Storage
+# (azurerm backend, access-key auth); the xcsh provider authenticates to the
+# production F5 XC tenant. All credentials come from repo secrets.
+on:
+  pull_request:
+    branches: [main]
+    paths: ['terraform/**', '.github/workflows/terraform.yml']
+  push:
+    branches: [main]
+    paths: ['terraform/**']
+
+permissions:
+  contents: read
+
+# Serialize state-mutating runs so no two applies race on the shared state blob.
+concurrency:
+  group: terraform-state
+  cancel-in-progress: false
+
+env:
+  # azurerm backend auth (storage account access key).
+  ARM_ACCESS_KEY: ${{ secrets.ARM_ACCESS_KEY }}
+  # xcsh provider auth (production tenant).
+  XCSH_API_URL: ${{ secrets.XCSH_API_URL }}
+  XCSH_API_TOKEN: ${{ secrets.XCSH_API_TOKEN }}
+  TF_IN_AUTOMATION: 'true'
+
+jobs:
+  terraform:
+    name: ${{ github.event_name == 'push' && 'apply' || 'plan' }}
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: terraform
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v4
+
+      - name: Init
+        run: terraform init -input=false
+
+      - name: Format check
+        run: terraform fmt -check -recursive
+
+      - name: Validate
+        run: terraform validate -no-color
+
+      - name: Plan
+        if: github.event_name == 'pull_request'
+        run: terraform plan -input=false -no-color
+
+      - name: Apply
+        if: github.event_name == 'push'
+        run: terraform apply -input=false -auto-approve -no-color

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -3,7 +3,8 @@ name: Terraform
 
 # Plan on PRs, apply on merge to main. State lives in Azure Blob Storage
 # (azurerm backend, access-key auth); the xcsh provider authenticates to the
-# production F5 XC tenant. All credentials come from repo secrets.
+# production F5 XC tenant. All credentials come from repo secrets, injected only
+# into the steps that need them.
 on:
   pull_request:
     branches: [main]
@@ -21,11 +22,6 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  # azurerm backend auth (storage account access key).
-  ARM_ACCESS_KEY: ${{ secrets.ARM_ACCESS_KEY }}
-  # xcsh provider auth (production tenant).
-  XCSH_API_URL: ${{ secrets.XCSH_API_URL }}
-  XCSH_API_TOKEN: ${{ secrets.XCSH_API_TOKEN }}
   TF_IN_AUTOMATION: 'true'
 
 jobs:
@@ -37,12 +33,14 @@ jobs:
         working-directory: terraform
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v4
+        uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
 
       - name: Init
+        env:
+          ARM_ACCESS_KEY: ${{ secrets.ARM_ACCESS_KEY }}
         run: terraform init -input=false
 
       - name: Format check
@@ -53,8 +51,16 @@ jobs:
 
       - name: Plan
         if: github.event_name == 'pull_request'
+        env:
+          ARM_ACCESS_KEY: ${{ secrets.ARM_ACCESS_KEY }}
+          XCSH_API_URL: ${{ secrets.XCSH_API_URL }}
+          XCSH_API_TOKEN: ${{ secrets.XCSH_API_TOKEN }}
         run: terraform plan -input=false -no-color
 
       - name: Apply
         if: github.event_name == 'push'
+        env:
+          ARM_ACCESS_KEY: ${{ secrets.ARM_ACCESS_KEY }}
+          XCSH_API_URL: ${{ secrets.XCSH_API_URL }}
+          XCSH_API_TOKEN: ${{ secrets.XCSH_API_TOKEN }}
         run: terraform apply -input=false -auto-approve -no-color

--- a/scripts/bootstrap-azure-state.sh
+++ b/scripts/bootstrap-azure-state.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Bootstrap the Azure Blob Storage backend for Terraform remote state (Phase 6).
+#
+# One-time, out-of-band setup: the state backend cannot store its own bootstrap
+# (chicken-and-egg). Run once with an authenticated Azure CLI session
+# (`az login`) that has Contributor on the subscription.
+#
+# Auth model: the azurerm backend authenticates with the storage account access
+# key (exported as ARM_ACCESS_KEY), NOT keyless OIDC/Azure AD — the subscription
+# grants only Contributor, which cannot assign the "Storage Blob Data
+# Contributor" role that keyless data-plane access requires. Contributor CAN read
+# the account key, so the key path needs no role assignment.
+set -euo pipefail
+
+SUBSCRIPTION="${AZURE_SUBSCRIPTION_ID:-75f86c46-9cbc-4f6c-85ea-195e3d3c8ac0}"
+RESOURCE_GROUP="f5-sales-demo-tfstate"
+STORAGE_ACCOUNT="f5salesdemotfstate"
+CONTAINER="tfstate"
+LOCATION="eastus2"
+
+az account set --subscription "$SUBSCRIPTION"
+
+az group create --name "$RESOURCE_GROUP" --location "$LOCATION" \
+  --tags managed_by=terraform use_case=dns purpose=tfstate
+
+az storage account create --name "$STORAGE_ACCOUNT" --resource-group "$RESOURCE_GROUP" \
+  --location "$LOCATION" --sku Standard_LRS --kind StorageV2 \
+  --min-tls-version TLS1_2 --allow-blob-public-access false \
+  --tags managed_by=terraform use_case=dns purpose=tfstate
+
+# State safety: keep prior versions and allow recovery of deleted state blobs.
+az storage account blob-service-properties update \
+  --account-name "$STORAGE_ACCOUNT" --resource-group "$RESOURCE_GROUP" \
+  --enable-versioning true \
+  --enable-delete-retention true --delete-retention-days 7 \
+  --enable-container-delete-retention true --container-delete-retention-days 7
+
+KEY="$(az storage account keys list \
+  --account-name "$STORAGE_ACCOUNT" --resource-group "$RESOURCE_GROUP" \
+  --query '[0].value' -o tsv)"
+
+az storage container create --name "$CONTAINER" \
+  --account-name "$STORAGE_ACCOUNT" --auth-mode key --account-key "$KEY"
+
+cat <<EOF
+
+Bootstrap complete.
+
+Export for local Terraform runs:
+  export ARM_ACCESS_KEY="<key>"   # az storage account keys list ... --query '[0].value' -o tsv
+
+Set as GitHub Actions secrets on f5-sales-demo/dns (for CI):
+  gh secret set ARM_ACCESS_KEY -R f5-sales-demo/dns
+  gh secret set XCSH_API_URL   -R f5-sales-demo/dns
+  gh secret set XCSH_API_TOKEN -R f5-sales-demo/dns
+EOF

--- a/terraform/.gitignore
+++ b/terraform/.gitignore
@@ -1,0 +1,19 @@
+# Terraform working files
+.terraform/
+.terraform.lock.hcl
+
+# State (local backend during prototyping — never commit)
+*.tfstate
+*.tfstate.*
+crash.log
+crash.*.log
+
+# Variable files may contain environment-specific values
+*.tfvars
+!*.tfvars.example
+
+# CLI config / credentials
+.terraformrc
+terraform.rc
+*.pem
+*.p12

--- a/terraform/.gitignore
+++ b/terraform/.gitignore
@@ -12,6 +12,10 @@ crash.*.log
 *.tfvars
 !*.tfvars.example
 
+# Local backend config (partial backend); example is committed
+backend.hcl
+!backend.hcl.example
+
 # CLI config / credentials
 .terraformrc
 terraform.rc

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -2,8 +2,8 @@
 
 Terraform plan that provisions the F5 Distributed Cloud DNS demo using the
 [`terraform-provider-xcsh`](https://github.com/f5-sales-demo/terraform-provider-xcsh)
-provider. It targets the production tenant against `f5-sales-demo.com` — our dedicated,
-delegated, pre-release test domain — with remote state in Azure Blob Storage.
+provider. It targets the production tenant against a dedicated, delegated, prerelease test
+domain, with remote state in Azure Blob Storage.
 
 ## Layout
 
@@ -46,22 +46,29 @@ RC
 Under `dev_overrides` the provider is not downloaded, but `terraform init` is still required
 once to configure the `azurerm` backend.
 
-### Credentials (never committed)
+### Configuration (nothing environment-specific is hardcoded)
 
-Export the F5 XC provider credentials and the Azure state backend key into the environment:
+No environment values live in the `.tf` files. Supply them at run time:
+
+| Value | CI source | Local source |
+| --- | --- | --- |
+| Backend coords (`resource_group_name`, `storage_account_name`, `container_name`, `key`) | GitHub **variables** `TFSTATE_*`, passed via `-backend-config` | `backend.hcl` (copy `backend.hcl.example`; gitignored) |
+| `domain`, `namespace` | GitHub **variables** `DNS_DOMAIN` / `DNS_NAMESPACE`, as `TF_VAR_*` | `terraform.tfvars` (copy the example; gitignored) or `TF_VAR_*` |
+| `ARM_ACCESS_KEY` (state auth) | GitHub **secret** | `export ARM_ACCESS_KEY=...` |
+| `XCSH_API_URL`, `XCSH_API_TOKEN` (provider auth) | GitHub **secrets** | `export XCSH_API_URL=... XCSH_API_TOKEN=...` |
 
 ```sh
-export XCSH_API_URL="https://f5-sales-demo.console.ves.volterra.io"
-export XCSH_API_TOKEN="<api-token>"          # provider auth (header: APIToken <token>)
-export ARM_ACCESS_KEY="<storage-account-key>" # azurerm backend auth
+export XCSH_API_URL="https://<tenant>.console.ves.volterra.io"
+export XCSH_API_TOKEN="<api-token>"           # provider auth (header: APIToken <token>)
+export ARM_ACCESS_KEY="<storage-account-key>" # azurerm backend auth (never committed)
+cp backend.hcl.example backend.hcl            # edit if your coords differ
+cp terraform.tfvars.example terraform.tfvars  # sets domain, namespace, records
 ```
-
-In CI these are the repo secrets `XCSH_API_URL`, `XCSH_API_TOKEN`, and `ARM_ACCESS_KEY`.
 
 ## Usage
 
 ```sh
-terraform init          # configures the azurerm backend
+terraform init -backend-config=backend.hcl   # partial backend: coords from backend.hcl
 terraform fmt -check
 terraform validate
 terraform plan
@@ -70,4 +77,4 @@ terraform destroy
 ```
 
 > DNS objects must be created in the `system` namespace (the API rejects others).
-> `f5-sales-demo.com` is delegated to F5 XC, so managed records resolve on the public internet.
+> The domain is delegated to F5 XC, so managed records resolve on the public internet.

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -48,7 +48,7 @@ once to configure the `azurerm` backend.
 
 ### Configuration (nothing environment-specific is hardcoded)
 
-No environment values live in the `.tf` files. Supply them at run time:
+No environment values live in the `.tf` files. Supply them at runtime:
 
 | Value | CI source | Local source |
 | --- | --- | --- |

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,0 +1,73 @@
+# DNS use-case Terraform reference plan
+
+Terraform plan that provisions the F5 Distributed Cloud DNS demo using the
+[`terraform-provider-xcsh`](https://github.com/f5-sales-demo/terraform-provider-xcsh)
+provider. It targets the production tenant against `f5-sales-demo.com` — our dedicated,
+delegated, pre-release test domain — with remote state in Azure Blob Storage.
+
+## Layout
+
+| Path | Purpose |
+| --- | --- |
+| `versions.tf` | Terraform + provider version pins |
+| `providers.tf` | `xcsh` provider (auth from environment) |
+| `backend.tf` | Azure Blob Storage remote state (`azurerm`, access-key auth) |
+| `variables.tf` / `terraform.tfvars.example` | Inputs (namespace, domain, labels, records) |
+| `main.tf` / `outputs.tf` | Module wiring |
+| `modules/dns-zone/` | Authoritative primary DNS zone with records |
+
+`modules/dns-lb/` (DNS Load Balancer: health check + pool + load balancer, plus `lb_record`
+entries in the zone) is a follow-up once the `lb_record` wire format is resolved.
+
+## Prerequisites
+
+- Terraform >= 1.5
+- The `xcsh` provider. Locally it is consumed via `dev_overrides` (below); CI uses the released
+  version pinned in `versions.tf` from the registry.
+- Azure remote-state backend bootstrapped once — see [`scripts/bootstrap-azure-state.sh`](../scripts/bootstrap-azure-state.sh).
+
+### Local provider (dev_overrides)
+
+Build the provider and point Terraform at the binary — each rebuild is picked up with no reinstall:
+
+```sh
+make -C ../../terraform-provider-xcsh build   # adjust path to your checkout
+
+cat > ~/.terraformrc <<'RC'
+provider_installation {
+  dev_overrides {
+    "registry.terraform.io/f5-sales-demo/xcsh" = "/absolute/path/to/terraform-provider-xcsh"
+  }
+  direct {}
+}
+RC
+```
+
+Under `dev_overrides` the provider is not downloaded, but `terraform init` is still required
+once to configure the `azurerm` backend.
+
+### Credentials (never committed)
+
+Export the F5 XC provider credentials and the Azure state backend key into the environment:
+
+```sh
+export XCSH_API_URL="https://f5-sales-demo.console.ves.volterra.io"
+export XCSH_API_TOKEN="<api-token>"          # provider auth (header: APIToken <token>)
+export ARM_ACCESS_KEY="<storage-account-key>" # azurerm backend auth
+```
+
+In CI these are the repo secrets `XCSH_API_URL`, `XCSH_API_TOKEN`, and `ARM_ACCESS_KEY`.
+
+## Usage
+
+```sh
+terraform init          # configures the azurerm backend
+terraform fmt -check
+terraform validate
+terraform plan
+terraform apply
+terraform destroy
+```
+
+> DNS objects must be created in the `system` namespace (the API rejects others).
+> `f5-sales-demo.com` is delegated to F5 XC, so managed records resolve on the public internet.

--- a/terraform/backend.hcl.example
+++ b/terraform/backend.hcl.example
@@ -1,0 +1,7 @@
+# Local backend config for the azurerm remote state (partial backend).
+# Copy to backend.hcl (gitignored) and init:  terraform init -backend-config=backend.hcl
+# These are the values bootstrapped by scripts/bootstrap-azure-state.sh.
+resource_group_name  = "f5-sales-demo-tfstate"
+storage_account_name = "f5salesdemotfstate"
+container_name       = "tfstate"
+key                  = "dns.tfstate"

--- a/terraform/backend.tf
+++ b/terraform/backend.tf
@@ -1,19 +1,17 @@
 terraform {
-  # Remote state in Azure Blob Storage (Phase 6).
+  # Azure Blob Storage remote state (Phase 6), configured as a PARTIAL backend:
+  # no environment-specific values are hardcoded here. Supply them at init time.
   #
-  # Auth is via the storage account access key, supplied out-of-band as the
-  # ARM_ACCESS_KEY environment variable (locally and as a GitHub Actions secret) —
-  # never committed. Keyless auth (use_oidc / use_azuread_auth) is not used: the
-  # subscription grants only Contributor, which cannot assign the
-  # "Storage Blob Data Contributor" role those methods require.
+  #   CI:    terraform init -backend-config="resource_group_name=$RG" \
+  #                         -backend-config="storage_account_name=$SA" \
+  #                         -backend-config="container_name=$CONTAINER" \
+  #                         -backend-config="key=$KEY"
+  #          (values from GitHub Actions repository variables; see .github/workflows/terraform.yml)
+  #   Local: terraform init -backend-config=backend.hcl   (copy backend.hcl.example; gitignored)
   #
-  # The backend storage (RG f5-sales-demo-tfstate, account f5salesdemotfstate,
-  # container tfstate) is bootstrapped once via the Azure CLI — see
-  # scripts/bootstrap-azure-state.sh.
-  backend "azurerm" {
-    resource_group_name  = "f5-sales-demo-tfstate"
-    storage_account_name = "f5salesdemotfstate"
-    container_name       = "tfstate"
-    key                  = "dns.tfstate"
-  }
+  # Auth is the storage account access key via the ARM_ACCESS_KEY environment
+  # variable (never committed). Keyless auth (use_oidc / use_azuread_auth) is not
+  # used: our Contributor-only RBAC cannot assign the "Storage Blob Data
+  # Contributor" role those methods require. Bootstrap: scripts/bootstrap-azure-state.sh.
+  backend "azurerm" {}
 }

--- a/terraform/backend.tf
+++ b/terraform/backend.tf
@@ -1,0 +1,19 @@
+terraform {
+  # Remote state in Azure Blob Storage (Phase 6).
+  #
+  # Auth is via the storage account access key, supplied out-of-band as the
+  # ARM_ACCESS_KEY environment variable (locally and as a GitHub Actions secret) —
+  # never committed. Keyless auth (use_oidc / use_azuread_auth) is not used: the
+  # subscription grants only Contributor, which cannot assign the
+  # "Storage Blob Data Contributor" role those methods require.
+  #
+  # The backend storage (RG f5-sales-demo-tfstate, account f5salesdemotfstate,
+  # container tfstate) is bootstrapped once via the Azure CLI — see
+  # scripts/bootstrap-azure-state.sh.
+  backend "azurerm" {
+    resource_group_name  = "f5-sales-demo-tfstate"
+    storage_account_name = "f5salesdemotfstate"
+    container_name       = "tfstate"
+    key                  = "dns.tfstate"
+  }
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,17 @@
+# DNS use-case reference plan.
+#
+# dns-zone — an authoritative primary zone with A records for the delegated
+# f5-sales-demo.com test domain.
+#
+# A follow-up adds ./modules/dns-lb (DNS Load Balancer: health check + pool +
+# load balancer, plus lb_record entries in the zone) once the lb_record wire
+# format is resolved.
+
+module "dns_zone" {
+  source = "./modules/dns-zone"
+
+  domain    = var.domain
+  namespace = var.namespace
+  labels    = var.labels
+  a_records = var.a_records
+}

--- a/terraform/modules/dns-zone/main.tf
+++ b/terraform/modules/dns-zone/main.tf
@@ -1,0 +1,30 @@
+# Manages an F5 XC authoritative primary DNS zone with A records.
+#
+# DNS objects must be created in the 'system' namespace, the zone name must be an
+# FQDN the account owns, and record TTLs must be >= 60.
+resource "xcsh_dns_zone" "this" {
+  name      = var.domain
+  namespace = var.namespace
+  labels    = var.labels
+
+  primary {
+    default_soa_parameters {}
+
+    rr_set_group {
+      metadata {
+        name = "demo-records"
+      }
+
+      dynamic "rr_set" {
+        for_each = var.a_records
+        content {
+          ttl = var.record_ttl
+          a_record {
+            name   = rr_set.key
+            values = rr_set.value
+          }
+        }
+      }
+    }
+  }
+}

--- a/terraform/modules/dns-zone/outputs.tf
+++ b/terraform/modules/dns-zone/outputs.tf
@@ -1,0 +1,9 @@
+output "name" {
+  description = "Zone name (FQDN)."
+  value       = xcsh_dns_zone.this.name
+}
+
+output "id" {
+  description = "F5 XC identifier of the DNS zone."
+  value       = xcsh_dns_zone.this.id
+}

--- a/terraform/modules/dns-zone/variables.tf
+++ b/terraform/modules/dns-zone/variables.tf
@@ -1,0 +1,28 @@
+variable "domain" {
+  description = "Zone FQDN (also the resource name). The account must own this domain."
+  type        = string
+}
+
+variable "namespace" {
+  description = "F5 XC namespace (must be 'system' for DNS objects)."
+  type        = string
+  default     = "system"
+}
+
+variable "labels" {
+  description = "Labels applied to the DNS zone."
+  type        = map(string)
+  default     = {}
+}
+
+variable "a_records" {
+  description = "A records for the zone: map of record name (\"\" = apex) to list of IPv4 addresses."
+  type        = map(list(string))
+  default     = {}
+}
+
+variable "record_ttl" {
+  description = "TTL for the demo records (F5 XC requires >= 60)."
+  type        = number
+  default     = 300
+}

--- a/terraform/modules/dns-zone/versions.tf
+++ b/terraform/modules/dns-zone/versions.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_providers {
+    xcsh = {
+      source = "f5-sales-demo/xcsh"
+    }
+  }
+}

--- a/terraform/modules/dns-zone/versions.tf
+++ b/terraform/modules/dns-zone/versions.tf
@@ -1,7 +1,10 @@
 terraform {
+  required_version = ">= 1.5"
+
   required_providers {
     xcsh = {
-      source = "f5-sales-demo/xcsh"
+      source  = "f5-sales-demo/xcsh"
+      version = ">= 3.61.15"
     }
   }
 }

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,0 +1,9 @@
+output "dns_zone_name" {
+  description = "Name of the managed DNS zone."
+  value       = module.dns_zone.name
+}
+
+output "dns_zone_id" {
+  description = "F5 XC identifier of the managed DNS zone."
+  value       = module.dns_zone.id
+}

--- a/terraform/providers.tf
+++ b/terraform/providers.tf
@@ -1,0 +1,9 @@
+# The xcsh provider authenticates from the environment — no secrets in code.
+# Export one of the following credential sets before running Terraform:
+#
+#   Token auth:  XCSH_API_URL + XCSH_API_TOKEN
+#   P12 auth:    XCSH_API_URL + XCSH_P12_FILE + XCSH_P12_PASSWORD
+#   PEM auth:    XCSH_API_URL + XCSH_CERT + XCSH_KEY
+#
+# See terraform/README.md for local dev setup (dev_overrides + env).
+provider "xcsh" {}

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -1,0 +1,18 @@
+# Copy to terraform.tfvars and adjust. terraform.tfvars is gitignored.
+# Credentials are NOT set here — export XCSH_API_URL + XCSH_API_TOKEN in the
+# environment (see terraform/README.md).
+
+namespace = "system"
+domain    = "f5-sales-demo.com"
+
+labels = {
+  managed_by = "terraform"
+  use_case   = "dns"
+}
+
+# A records: record name ("" = apex) -> list of IPv4 addresses.
+a_records = {
+  www = ["203.0.113.10"]
+  app = ["203.0.113.20"]
+  api = ["203.0.113.30"]
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -10,9 +10,8 @@ variable "namespace" {
 }
 
 variable "domain" {
-  description = "DNS zone FQDN. f5-sales-demo.com is our delegated, pre-release test domain in the production tenant."
+  description = "DNS zone FQDN (required; supplied via TF_VAR_domain / a GitHub Actions variable / tfvars — not hardcoded). Our delegated, prerelease test domain in the production tenant."
   type        = string
-  default     = "f5-sales-demo.com"
 }
 
 variable "labels" {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,35 @@
+variable "namespace" {
+  description = "F5 XC namespace for DNS objects. DNS objects MUST live in 'system' (the API rejects other namespaces)."
+  type        = string
+  default     = "system"
+
+  validation {
+    condition     = var.namespace == "system"
+    error_message = "F5 XC DNS objects must be created in the 'system' namespace."
+  }
+}
+
+variable "domain" {
+  description = "DNS zone FQDN. f5-sales-demo.com is our delegated, pre-release test domain in the production tenant."
+  type        = string
+  default     = "f5-sales-demo.com"
+}
+
+variable "labels" {
+  description = "Labels applied to managed DNS objects."
+  type        = map(string)
+  default = {
+    managed_by = "terraform"
+    use_case   = "dns"
+  }
+}
+
+variable "a_records" {
+  description = "A records for the zone: record name (\"\" = apex) to list of IPv4 addresses. Mirrors manifests/f5-sales-demo-com.json (RFC 5737 documentation addresses)."
+  type        = map(list(string))
+  default = {
+    www = ["203.0.113.10"]
+    app = ["203.0.113.20"]
+    api = ["203.0.113.30"]
+  }
+}

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    xcsh = {
+      source = "f5-sales-demo/xcsh"
+      # First registry release that ships the DNS resources (xcsh_dns_zone,
+      # dns_lb_*, geo_location_set). Earlier releases lack them. Locally the
+      # provider is consumed via dev_overrides, which ignores this constraint.
+      version = ">= 3.61.15"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Promotes the DNS use-case Terraform plan to the **production** F5 XC tenant against
`f5-sales-demo.com` (our dedicated, delegated, pre-release test domain), and moves state to
**Azure Blob Storage**.

- `backend.tf`: `local` → `azurerm` (RG `f5-sales-demo-tfstate`, account `f5salesdemotfstate`,
  container `tfstate`, key `dns.tfstate`). Auth via storage **access key** (`ARM_ACCESS_KEY`) —
  keyless OIDC/Azure AD isn't possible under the subscription's Contributor-only RBAC.
- `scripts/bootstrap-azure-state.sh`: one-time `az` bootstrap of the backend (versioning +
  soft-delete enabled).
- `.github/workflows/terraform.yml`: plan-on-PR / apply-on-merge, serialized on a `terraform-state`
  concurrency group, using repo secrets `ARM_ACCESS_KEY`, `XCSH_API_URL`, `XCSH_API_TOKEN`.
- `versions.tf`: pin `xcsh >= 3.61.15`.

## Verified end-to-end (local, against prod)

- `terraform apply` creates `xcsh_dns_zone` for `f5-sales-demo.com` in the `system` namespace.
- `terraform plan` afterward is **idempotent** (`No changes`).
- State blob `dns.tfstate` written to the Azure `tfstate` container.
- **Public resolution works:** `dig www.f5-sales-demo.com` → `203.0.113.10`.

## Known dependency (CI)

The `terraform` workflow's plan/apply need a **published provider release containing the DNS
resources**. Latest `f5-sales-demo/xcsh` release **v3.61.14 predates them** (added in
terraform-provider-xcsh#975, 5 commits later; no release since — the v3.61.15 attempt OOM'd).
Local runs use `dev_overrides`. **CI goes green once v3.61.15 is published** from current
`terraform-provider-xcsh` `main` (which also carries the GoReleaser parallelism fix). This
workflow is a non-required check, so it does not block merge.

Closes #503
