### PR TITLE
feat: allow HTTP LB-managed records; cede www/api to webapp-api-protection

### DIFF
--- a/terraform/modules/dns-zone/main.tf
+++ b/terraform/modules/dns-zone/main.tf
@@ -8,6 +8,11 @@ resource "xcsh_dns_zone" "this" {
   labels = var.labels
 
   primary {
+    # Allow HTTP/TCP/CDN load balancers to auto-manage their resource records
+    # (e.g. www / api) in a protected RRset. Consumed by the webapp-api-protection
+    # load balancer, which owns www.f5-sales-demo.com and api.f5-sales-demo.com.
+    allow_http_lb_managed_records = true
+
     default_soa_parameters {}
 
     rr_set_group {

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -10,8 +10,8 @@ labels = {
 }
 
 # A records: record name ("" = apex) -> list of IPv4 addresses.
+# www and api are owned by the webapp-api-protection HTTP load balancer
+# (allow_http_lb_managed_records) — do NOT declare them here.
 a_records = {
-  www = ["203.0.113.10"]
   app = ["203.0.113.20"]
-  api = ["203.0.113.30"]
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -13,11 +13,9 @@ variable "labels" {
 }
 
 variable "a_records" {
-  description = "A records for the zone: record name (\"\" = apex) to list of IPv4 addresses. Mirrors manifests/f5-sales-demo-com.json (RFC 5737 documentation addresses)."
+  description = "Static A records for the zone: record name (\"\" = apex) to list of IPv4 addresses. NOTE: www and api are intentionally NOT managed here — they are owned by the webapp-api-protection HTTP load balancer via allow_http_lb_managed_records (F5 XC auto-manages those records to the LB VIP). Keep only records not fronted by an XC load balancer."
   type        = map(list(string))
   default = {
-    www = ["203.0.113.10"]
     app = ["203.0.113.20"]
-    api = ["203.0.113.30"]
   }
 }


### PR DESCRIPTION
Enables `allow_http_lb_managed_records` on the `f5-sales-demo.com` zone and removes the static `www`/`api` A records so the webapp-api-protection HTTP load balancer owns those names (F5 XC managed RRset).

## Applied + verified (production, via the real dns.tfstate)
- `terraform apply`: 1 changed, 0 destroyed (in-place zone update).
- API re-probe: `allow_http_lb_managed_records=true`; only `app` static A record remains; www/api ceded.

Closes #521