### PR TITLE
feat: onboard dns to the self-hosted Claude reviewer (advisory) (#535)

### DIFF
--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -1,0 +1,23 @@
+name: Code Review
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+jobs:
+  review:
+    # Skip fork PRs (never reach the self-hosted runner) and automated bot
+    # branches so governance/dependabot PRs aren't gated on the laptop runner.
+    if: >-
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      !startsWith(github.head_ref, 'governance/') &&
+      !startsWith(github.head_ref, 'sync/') &&
+      !startsWith(github.head_ref, 'dependabot/') &&
+      !startsWith(github.head_ref, 'release/')
+    uses: f5-sales-demo/code-review/.github/workflows/claude-review.yml@main
+    permissions:
+      contents: read
+      pull-requests: write
+    secrets:
+      F5_GATEWAY_TOKEN: ${{ secrets.F5_GATEWAY_TOKEN }}
+      REPO_SETTINGS_TOKEN: ${{ secrets.REPO_SETTINGS_TOKEN }}
+    with:
+      verify_cmd: "cd terraform && terraform init -backend=false && terraform validate"

--- a/actionlint.yml
+++ b/actionlint.yml
@@ -1,0 +1,9 @@
+---
+# Repo-local actionlint config. The Claude reviewer runs on a repo-level
+# self-hosted runner labeled "code-review"; register it so actionlint accepts
+# `runs-on: [self-hosted, macOS, code-review]`.
+self-hosted-runner:
+  labels:
+    - code-review
+
+config-variables: null


### PR DESCRIPTION
Closes #535. Advisory Claude reviewer on dns via its repo-level self-hosted runner. This PR itself is the pilot (the reviewer runs on it).