### PR TITLE
Gitignore Terraform *_override.tf (closes #547)

### DIFF
--- a/terraform/.gitignore
+++ b/terraform/.gitignore
@@ -2,6 +2,11 @@
 .terraform/
 .terraform.lock.hcl
 
+# Override files (e.g. the temporary backend_override.tf that
+# .code-review/verify.sh writes for credential-free validation)
+*_override.tf
+*_override.tf.json
+
 # State (local backend during prototyping — never commit)
 *.tfstate
 *.tfstate.*


### PR DESCRIPTION
## What

Adds `*_override.tf` / `*_override.tf.json` to `terraform/.gitignore`.

## Why

`.code-review/verify.sh` writes a temporary `backend_override.tf` and removes it
via an EXIT trap. If hard-killed (SIGKILL) the trap is skipped and the file
survives — previously un-ignored, so a later `git add -A` could commit it (a
committed `backend "local"` override would break real state ops). Flagged by the
governed Claude reviewer on PR #546 (🟡 low, non-blocking).

## Verification

- `git check-ignore terraform/backend_override.tf` -> ignored ✅
- No `*_override.tf` is committed in the repo.

Closes #547