### PR TITLE
fix(terraform): require xcsh provider >= 3.72.18 for x-ves-io-managed fix (closes #549)

### DIFF
--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -4,10 +4,14 @@ terraform {
   required_providers {
     xcsh = {
       source = "f5-sales-demo/xcsh"
-      # >= 3.62.0: release where the namespace attribute for system-only DNS
-      # resources defaults to "system" (spec-driven), so it can be omitted.
+      # >= 3.72.18: release where the provider stops surfacing the F5XC
+      # system-managed "x-ves-io-managed" rr_set_group (auto-created when
+      # allow_http_lb_managed_records = true) as Terraform state. Earlier
+      # releases planned to delete that group, and apply failed 403 FORBIDDEN
+      # (the group is platform-owned). See terraform-provider-xcsh #1167.
+      # (Floor also covers >= 3.62.0: namespace defaults to "system", spec-driven.)
       # Locally the provider is consumed via dev_overrides, which ignores this.
-      version = ">= 3.62.0"
+      version = ">= 3.72.18"
     }
   }
 }


### PR DESCRIPTION
## What

Bumps the `f5-sales-demo/xcsh` provider floor `>= 3.62.0` → `>= 3.72.18`.

## Why

The Terraform `apply`-on-main was failing (run 29741124417):

```
Unable to update DNSZone: [FORBIDDEN] Access denied - insufficient permissions
(resource: .../dns_zones/f5-sales-demo.com) (operation: PUT) (status: 403)
```

Root cause (fixed in **terraform-provider-xcsh #1167**, released **v3.72.18**): the
provider round-tripped the F5XC **system-managed** `x-ves-io-managed` rr_set_group
(auto-created because `primary.allow_http_lb_managed_records = true`; holds the www/api
records owned by webapp-api-protection) into Terraform state. Our config declares only
`demo-records`, so plan tried to **delete** the platform-owned group → 403 on apply.

v3.72.18 no longer surfaces that group as state. With the fixed provider the stale
group drops from state on refresh, so `plan` shows no spurious delete and `apply`
succeeds.

## Verification

- `terraform fmt -check` clean.
- **This PR's `plan` job** resolves v3.72.18 from the registry and must show **no
  delete** of `x-ves-io-managed` (previously "1 to change").
- On merge, the `apply` job must go **green** (0 changes) — the definitive end-to-end
  proof, turning dns main CI green again.

Closes #549