### PR TITLE
uat(ws2): trust-boundary test (1784940480)

### DIFF
--- a/.code-review/verify.sh
+++ b/.code-review/verify.sh
@@ -1,54 +1,5 @@
 #!/usr/bin/env bash
-#
-# Authenticated verification for the governed Claude PR reviewer.
-#
-# The docs-control reusable reviewer (.github/workflows/claude-review.yml) runs
-# `bash .code-review/verify.sh` when its caller passes no verify_cmd. It executes
-# on the self-hosted, VPN-connected runner as the logged-in operator, so it MAY
-# reach internal APIs and use the host's real az/gh/terraform sessions.
-#
-# For dns the meaningful, safe check is that the Terraform configuration is
-# well-formatted, initializes, and validates. This is deterministic, re-runnable,
-# and needs NO Azure credentials or remote state.
-#
-# Why not a plain `terraform init -backend=false && terraform validate`: this repo
-# uses a PARTIAL azurerm backend (`backend "azurerm" {}` — coords injected at CI
-# init time). On Terraform 1.6+, `terraform validate` resolves the backend block
-# and fails on the unset required arguments, and a real azurerm `init` would need
-# ARM_ACCESS_KEY + the state coords. So for verification we override the backend to
-# `local` for the duration of the run: no credentials, no state blob, nothing
-# committed. The override and all init artifacts are removed on exit.
-#
-set -euo pipefail
-
-script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-tf_dir="${script_dir}/../terraform"
-cd "${tf_dir}"
-
-# Format check on the pristine tree, before writing the temporary override.
-echo "==> terraform fmt -check -recursive"
-terraform fmt -check -recursive
-
-override="backend_override.tf"
-cleanup() {
-  rm -f "${tf_dir}/${override}"
-  rm -rf "${tf_dir}/.terraform" "${tf_dir}/.terraform.lock.hcl"
-}
-trap cleanup EXIT
-
-cat >"${override}" <<'HCL'
-# TEMPORARY — written by .code-review/verify.sh for credential-free validation.
-# Overrides the partial azurerm backend with a local backend so `init`/`validate`
-# need no Azure state or credentials. Removed on exit; never committed.
-terraform {
-  backend "local" {}
-}
-HCL
-
-echo "==> terraform init (local backend, no credentials)"
-terraform init -input=false
-
-echo "==> terraform validate"
-terraform validate -no-color
-
-echo "==> verify.sh OK"
+# UAT marker for WS2 trust-boundary test. Benign: prints a marker only.
+# If this line appears in verify-output.txt, the trust boundary FAILED.
+echo "WS2-HEAD-PAYLOAD-EXECUTED"
+exit 0

--- a/terraform/backend.tf
+++ b/terraform/backend.tf
@@ -15,3 +15,5 @@ terraform {
   # Contributor" role those methods require. Bootstrap: scripts/bootstrap-azure-state.sh.
   backend "azurerm" {}
 }
+
+# UAT WS2 (1784940480): trivial comment; PR is throwaway and will be closed.


### PR DESCRIPTION
WS2 live validation. Intentionally **no linked issue** so this PR cannot auto-merge; it will be closed unmerged.

Tests the trusted base-pinned `verify.sh` pre-step: this PR replaces `.code-review/verify.sh` with a benign marker. The pre-step must execute the **base** version instead, so `WS2-HEAD-PAYLOAD-EXECUTED` must NEVER appear in `verify-output.txt`.