### PR TITLE
chore: sync managed files from governance template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -163,6 +163,7 @@ docs/specifications/api/
 docs/api-reference/
 .version
 .etag
+.etag_cache
 .github_release
 
 # Autoresearch session artifacts


### PR DESCRIPTION
Closes #745

Synced managed files from `f5-sales-demo/docs-control` canonical source:

- .gitignore