### PR TITLE
ci: migrate custom workflows to self-hosted runners

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -35,6 +35,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -28,7 +28,7 @@ env:
 jobs:
   terraform:
     name: ${{ github.event_name == 'push' && 'apply' || 'plan' }}
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64, dns]
     defaults:
       run:
         working-directory: terraform

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -28,7 +28,7 @@ env:
 jobs:
   terraform:
     name: ${{ github.event_name == 'push' && 'apply' || 'plan' }}
-    runs-on: [self-hosted, Linux, X64, dns]
+    runs-on: [self-hosted, Linux, X64, dns, ubuntu-24.04]
     defaults:
       run:
         working-directory: terraform

--- a/actionlint.yml
+++ b/actionlint.yml
@@ -1,7 +1,46 @@
 ---
 self-hosted-runner:
   labels:
+    - administration
+    - api-protection
+    - api-specs
+    - api-specs-enriched
+    - apt-repo
+    - bot-advanced
+    - bot-standard
+    - cdn
+    - cdn-simulator
+    - console
+    - container-build
+    - csd
+    - ddos
+    - demo-resource-template
+    - demo-resources
+    - devcontainer
+    - dns
+    - docs
+    - docs-builder
+    - docs-control
+    - docs-icons
+    - docs-theme
+    - i18n-core
+    - marketplace
+    - marketplace-claude-code
+    - mcn
+    - nginx
+    - observability
+    - origin-server
+    - starlight-llms-txt
+    - starlight-mega-menu
     - terraform-provider-xcsh
+    - traffic-generator
     - ubuntu-24.04-arm
+    - vscode-xcsh
+    - waf
+    - was
+    - webapp-api-protection
+    - xcsh
+    - xcsh-action
+    - xcsh-chrome-extension
 
 config-variables: null


### PR DESCRIPTION
Closes #766

- route Linux jobs to repository-scoped self-hosted runners
- preserve explicit native macOS, Windows, and ARM64 coverage where applicable
- pin Marketplace actions to current stable release SHAs

Validation: central runner-routing and immutable-pin audit; actionlint syntax validation; git diff checks.